### PR TITLE
fix: replace pngmath with mathjax for compatibility with Sphinx 8

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath']
+extensions = ['sphinx.ext.todo', 'sphinx.ext.mathjax']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
## Fix Sphinx build error caused by deprecated pngmath extension

### Problem

When building the documentation using `python3-sphinx` and `make`, the build fails due to the use of the deprecated `pngmath` extension.

Sphinx 8 no longer supports `pngmath`, which causes the build to break.

### Solution

Replace `pngmath` with `mathjax` in the Sphinx configuration to ensure compatibility with Sphinx 8.

### Changes

- Removed deprecated `pngmath` extension
- Enabled `mathjax` for math rendering
- Ensured successful build with Sphinx 8

### Result

The documentation builds successfully after this change.

### Notes

Other warnings observed during the build are not addressed in this change and may be handled in a future PR.